### PR TITLE
Prevent setting coverage note on pull requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,7 +462,10 @@ async function generateReport() {
     pkg_stats: current.pkg_stats,
     skipped_count: current.skipped_count,
   };
-  await setCoverageNote(nowData);
+
+  if (!ctx.payload.pull_request) { // Don't set notes for PRs
+    await setCoverageNote(nowData);
+  }
 
   if (!stats.meetsThreshold) {
     const fail_policy = core.getInput('fail-coverage');


### PR DESCRIPTION
Fixes #74

Another side-effect of running from a public fork that I found was that you cannot add comments to the PR. However, this is solvable by setting `add-comment: false` (alternatively, I suppose using a PAT would allow adding comments, but for our use-case we don't want to do that)