### PR TITLE
build: add -f option to push to overwrite in case of simultaneous pus…

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ async function setCoverageNote(data) {
     ['notes', `--ref=${notesRef}`, 'add', '-f', '--file=-', ctx.sha],
     jsdata
   );
-  await exec('git', ['push', 'origin', `refs/notes/${notesRef}`]);
+  await exec('git', ['push', '-f', 'origin', `refs/notes/${notesRef}`]);
 }
 
 async function getPriorCoverage() {

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ async function setCoverageNote(data) {
     ['notes', `--ref=${notesRef}`, 'add', '-f', '--file=-', ctx.sha],
     jsdata
   );
-  await exec('git', ['push', '-f', 'origin', `refs/notes/${notesRef}`]);
+  await exec('git', ['push', '--force-with-lease', 'origin', `refs/notes/${notesRef}`]);
 }
 
 async function getPriorCoverage() {


### PR DESCRIPTION
build: add -f option to push to overwrite in case of simultaneous push and pull request build triggers
    
- Issue: When both push and pull request trigger builds simultaneously, notes may be pushed twice
- Solution: Add the -f option to the second push to ensure it overwrites the previous one